### PR TITLE
add ci validation and normalized-branch automation

### DIFF
--- a/.github/workflows/normalize-routes.yml
+++ b/.github/workflows/normalize-routes.yml
@@ -1,0 +1,65 @@
+# Rebuilds the `normalized` branch whenever route files change on main.
+# Originals on main are never modified -- they keep their original metadata
+# and coordinate precision. The normalized branch gets canonical
+# FeatureCollections: 6-decimal coordinates, no legacy crs member, and a
+# ProjectID property on every feature (see scripts/normalize_geojson.py).
+#
+# Validation runs first; if any route file on main is invalid, the
+# normalized branch is not updated until main is fixed.
+
+name: normalize routes
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'data/individual-routes/**'
+      - 'scripts/normalize_geojson.py'
+      - 'scripts/validate_geojson.py'
+      - '.github/workflows/normalize-routes.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: normalize-routes
+  cancel-in-progress: true
+
+jobs:
+  normalize:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: validate all route files
+        run: python3 scripts/validate_geojson.py --all
+
+      - name: build normalized tree
+        run: python3 scripts/normalize_geojson.py --out "$RUNNER_TEMP/normalized"
+
+      - name: commit and push to normalized branch
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if git fetch origin normalized; then
+            git worktree add --detach "$RUNNER_TEMP/norm-branch" FETCH_HEAD
+            cd "$RUNNER_TEMP/norm-branch"
+          else
+            # first run: start the branch with no shared history
+            git worktree add --detach "$RUNNER_TEMP/norm-branch"
+            cd "$RUNNER_TEMP/norm-branch"
+            git switch --orphan normalized-build
+          fi
+
+          find . -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
+          cp -R "$RUNNER_TEMP/normalized/." .
+          git add -A
+
+          if git diff --cached --quiet; then
+            echo "normalized routes unchanged -- nothing to push"
+          else
+            git commit -m "normalize routes from ${GITHUB_SHA::7}"
+            git push origin HEAD:refs/heads/normalized
+          fi

--- a/.github/workflows/validate-routes.yml
+++ b/.github/workflows/validate-routes.yml
@@ -1,0 +1,44 @@
+# Validates route GeoJSON files changed in a pull request:
+# valid JSON/GeoJSON, WGS 84, no Z coordinates, coordinates in range,
+# filename matches P####.geojson, no duplicate ProjectID across fuel folders.
+# Run manually (workflow_dispatch) to audit every file in the repo.
+
+name: validate routes
+
+on:
+  pull_request:
+    paths:
+      - 'data/individual-routes/**/*.geojson'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: collect changed route files
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --paginate --jq '.[] | select(.status != "removed") | .filename' \
+            | { grep -E '^data/individual-routes/.+\.geojson$' || true; } > changed-files.txt
+          echo "$(wc -l < changed-files.txt) changed route file(s)"
+
+      - name: validate changed files
+        if: github.event_name == 'pull_request'
+        run: |
+          if [ -s changed-files.txt ]; then
+            xargs python3 scripts/validate_geojson.py < changed-files.txt
+          else
+            echo "no route files to validate"
+          fi
+
+      - name: validate all files
+        if: github.event_name == 'workflow_dispatch'
+        run: python3 scripts/validate_geojson.py --all

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GOIT-GGIT-pipeline-routes
 This is a GitHub repository at Global Energy Monitor to store pipeline routes.
 
-Individual routes are stored as `[ProjectID].geojson`, in the `data > individual-files` folder.
+Individual routes are stored as `[ProjectID].geojson` in the `data/individual-routes` folder, split by fuel into `gas-pipelines`, `liquid-pipelines`, and `hydrogen-pipelines`. Each ProjectID lives in exactly one fuel folder.
 
 ## Every project has a GeoJSON file associated with it.
 If a given project does not have a route, either because it's a capacity expansion with no actual new pipeline associated with it, or because we haven't created the route yet or cannot find a map to trace online, we STILL create a `.geojson` file for it, it's just stored as an **empty GeoJSON file** (i.e., `None`-type geometry).
@@ -37,3 +37,27 @@ If you update a route or multiple routes...
 ## Coordinate reference system
 
 The [GeoJSON](https://geojson.org/) file format specification says that GeoJSON files use a WSG 84 (EPSG:4326) coordinate reference system, so this is expected for all pipelines and no crs is required in the GeoJSON file.
+
+## Automated checks
+
+Every pull request that changes route files is checked automatically by GitHub Actions (`.github/workflows/validate-routes.yml`). The checks fail the PR if a file:
+
+* is not valid JSON / GeoJSON
+* declares a coordinate reference system other than WGS 84 (EPSG:4326 / CRS84)
+* contains Z coordinates (positions must be `[longitude, latitude]` only)
+* has coordinates outside valid longitude/latitude ranges
+* is not named `[ProjectID].geojson` (or `[ProjectID]-compressor-stations.geojson`)
+* uses a ProjectID that already exists in a different fuel folder
+
+You can run the same checks locally before pushing:
+
+```
+python3 scripts/validate_geojson.py path/to/P1234.geojson    # specific files
+python3 scripts/validate_geojson.py --all                    # the whole repo
+```
+
+## The `normalized` branch (generated — do not edit)
+
+The `main` branch always holds the **original** files exactly as submitted — original metadata, original coordinate precision — so researchers who scrape routes get untouched data.
+
+The [`normalized`](../../tree/normalized) branch holds a standardized copy of every route, rebuilt automatically by GitHub Actions (`.github/workflows/normalize-routes.yml`) whenever route files change on `main`. Normalized files are canonical FeatureCollections with coordinates rounded to 6 decimal places (~10 cm), no legacy `crs` member, and a `ProjectID` property on every feature. Never commit to that branch by hand — any change will be overwritten on the next rebuild.

--- a/scripts/normalize_geojson.py
+++ b/scripts/normalize_geojson.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Build the normalized/standardized copy of every pipeline-route GeoJSON.
+
+This produces the contents of the `normalized` branch. Originals on `main`
+are never touched -- they keep their original metadata and full coordinate
+precision for researchers who scrape them.
+
+Normalization rules:
+  - top level is always a FeatureCollection (a bare top-level Feature is
+    wrapped)
+  - the legacy `crs` member is removed (RFC 7946 GeoJSON is always WGS 84)
+  - coordinates are rounded to 6 decimal places (~10 cm) and any Z values
+    are dropped
+  - every feature gets a ProjectID property matching the filename; if the
+    original file carried a different ProjectID (e.g. the route was copied
+    from a related project), that value is preserved as SourceProjectID
+  - other feature properties and feature ids are preserved as-is, except
+    properties whose value is an embedded JSON copy of a geometry (e.g. a
+    GEOJSON field from a source-data export), which are dropped as redundant
+  - files with no features become a single null-geometry feature, matching
+    the empty-route convention in README.md
+  - deterministic serialization: one feature per line, stable key order,
+    so unchanged inputs always produce byte-identical outputs
+
+Usage:
+  normalize_geojson.py --out DIR [--precision 6]
+
+Reads every data/individual-routes/*/*.geojson in this repo and writes the
+same tree (plus a branch README) under DIR. Requires only the Python
+standard library.
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ROUTES_DIR = REPO_ROOT / "data" / "individual-routes"
+
+FILENAME_RE = re.compile(r"^(P\d{4,6})(-compressor-stations?)?\.geojson$")
+
+BRANCH_README = """\
+# normalized pipeline routes (generated -- do not edit)
+
+This branch is rebuilt automatically from `main` by the
+`normalize-routes` GitHub Actions workflow whenever route files change.
+Do not commit to it or open pull requests against it; any manual change
+will be overwritten on the next rebuild.
+
+Compared to the original files on `main`, every file here:
+
+- is a canonical GeoJSON FeatureCollection (WGS 84, no legacy `crs` member)
+- has coordinates rounded to 6 decimal places (~10 cm) with no Z values
+- carries a `ProjectID` property on every feature, matching the filename
+  (where the original file carried a different `ProjectID`, that value is
+  preserved as `SourceProjectID`)
+
+If you want the original files exactly as researchers submitted them --
+original metadata, original coordinate precision -- use the `main` branch.
+"""
+
+
+GEOMETRY_TYPES = {
+    "Point", "MultiPoint", "LineString", "MultiLineString",
+    "Polygon", "MultiPolygon", "GeometryCollection",
+}
+
+
+EMBEDDED_GEOMETRY_RE = re.compile(
+    r'^\s*\{\s*"type"\s*:\s*"(%s)"\s*,\s*"(coordinates|geometries)"'
+    % "|".join(GEOMETRY_TYPES)
+)
+
+
+def is_embedded_geometry(value):
+    """True if a property value is a JSON string encoding a geometry -- a
+    redundant copy of the feature's geometry left by some source-data
+    exports. Matched on structure rather than parsed, because these strings
+    are often truncated to 254 chars (shapefile DBF field limit) and no
+    longer valid JSON."""
+    return isinstance(value, str) and bool(EMBEDDED_GEOMETRY_RE.match(value))
+
+
+def round_coordinates(coords, precision):
+    """Recursively round a coordinates array and drop Z values."""
+    if not isinstance(coords, list):
+        return coords
+    if coords and all(isinstance(v, (int, float)) and not isinstance(v, bool) for v in coords):
+        # A single position: keep [lon, lat] only.
+        return [round(float(v), precision) for v in coords[:2]]
+    return [round_coordinates(item, precision) for item in coords]
+
+
+def normalize_geometry(geom, precision):
+    if geom is None:
+        return None
+    out = {"type": geom.get("type")}
+    if geom.get("type") == "GeometryCollection":
+        out["geometries"] = [
+            normalize_geometry(g, precision) for g in geom.get("geometries", [])
+        ]
+    else:
+        out["coordinates"] = round_coordinates(geom.get("coordinates"), precision)
+    return out
+
+
+def normalize_feature(feat, project_id, precision):
+    props = feat.get("properties")
+    props = dict(props) if isinstance(props, dict) else {}
+
+    original_pid = props.pop("ProjectID", None)
+    new_props = {}
+    if project_id is not None:
+        new_props["ProjectID"] = project_id
+        if original_pid is not None and str(original_pid).strip() != project_id:
+            new_props["SourceProjectID"] = str(original_pid).strip()
+    elif original_pid is not None:
+        new_props["ProjectID"] = original_pid
+    new_props.update(
+        (k, v) for k, v in props.items() if not is_embedded_geometry(v)
+    )
+
+    out = {"type": "Feature"}
+    if "id" in feat:
+        out["id"] = feat["id"]
+    out["properties"] = new_props
+    out["geometry"] = normalize_geometry(feat.get("geometry"), precision)
+    return out
+
+
+def normalize_file(src, precision):
+    """Return the normalized file content (str) for one source file."""
+    data = json.loads(src.read_text(encoding="utf-8"))
+
+    if isinstance(data, dict) and data.get("type") == "Feature":
+        features = [data]
+    elif isinstance(data, dict) and data.get("type") == "FeatureCollection":
+        features = [f for f in data.get("features", []) if isinstance(f, dict)]
+    else:
+        raise ValueError(f"{src}: not a Feature or FeatureCollection")
+
+    m = FILENAME_RE.match(src.name)
+    project_id = m.group(1) if m else None
+
+    if not features:
+        features = [{"type": "Feature", "properties": {}, "geometry": None}]
+    normalized = [normalize_feature(f, project_id, precision) for f in features]
+
+    feature_lines = ",\n".join(
+        json.dumps(f, ensure_ascii=False, separators=(", ", ": ")) for f in normalized
+    )
+    return (
+        '{\n"type": "FeatureCollection",\n"features": [\n'
+        + feature_lines
+        + "\n]\n}\n"
+    )
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--out", required=True, help="output directory for the normalized tree")
+    parser.add_argument("--precision", type=int, default=6, help="coordinate decimal places (default 6)")
+    args = parser.parse_args(argv)
+
+    out_root = Path(args.out)
+    files = sorted(ROUTES_DIR.glob("*/*.geojson"))
+    if not files:
+        print(f"no .geojson files found under {ROUTES_DIR}", file=sys.stderr)
+        return 2
+
+    n_failed = 0
+    bytes_in = 0
+    bytes_out = 0
+    for src in files:
+        try:
+            content = normalize_file(src, args.precision)
+        except (ValueError, json.JSONDecodeError, OSError) as e:
+            print(f"FAIL  {src}: {e}", file=sys.stderr)
+            n_failed += 1
+            continue
+        dest = out_root / src.relative_to(REPO_ROOT)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(content, encoding="utf-8")
+        bytes_in += src.stat().st_size
+        bytes_out += len(content.encode("utf-8"))
+
+    (out_root / "README.md").write_text(BRANCH_README, encoding="utf-8")
+
+    print(
+        f"normalized {len(files) - n_failed}/{len(files)} files: "
+        f"{bytes_in / 1e6:.1f} MB -> {bytes_out / 1e6:.1f} MB"
+    )
+    return 1 if n_failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/validate_geojson.py
+++ b/scripts/validate_geojson.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Validate GEM pipeline-route GeoJSON files.
+
+Checks each file for:
+  - valid JSON, top-level FeatureCollection (or a single top-level Feature)
+  - filename matches P####.geojson or P####-compressor-station(s).geojson
+  - CRS is WGS 84 / CRS84 (or no crs member at all, per RFC 7946)
+  - no Z coordinates (positions must be [lon, lat] only)
+  - longitude in [-180, 180], latitude in [-90, 90]
+  - the same ProjectID file does not exist in more than one fuel folder
+
+Warnings (reported but do not fail validation):
+  - a ProjectID property that does not match the filename (this is common
+    when a route was copied from a related project)
+
+Empty routes (geometry: null) are valid -- see README.md.
+
+Usage:
+  validate_geojson.py FILE [FILE ...]    validate specific files
+  validate_geojson.py --all              validate every route file in the repo
+
+Exits nonzero if any file fails. Requires only the Python standard library.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ROUTES_DIR = REPO_ROOT / "data" / "individual-routes"
+
+FILENAME_RE = re.compile(r"^(P\d{4,6})(-compressor-stations?)?\.geojson$")
+
+# Acceptable spellings of the (optional) legacy crs member. RFC 7946 GeoJSON
+# is always WGS 84, so the only valid crs declarations are the equivalents.
+ACCEPTED_CRS = {
+    "urn:ogc:def:crs:OGC:1.3:CRS84",
+    "urn:ogc:def:crs:OGC::CRS84",
+    "urn:ogc:def:crs:EPSG::4326",
+    "OGC:CRS84",
+    "CRS84",
+    "EPSG:4326",
+}
+
+GEOMETRY_TYPES = {
+    "Point", "MultiPoint", "LineString", "MultiLineString",
+    "Polygon", "MultiPolygon", "GeometryCollection",
+}
+
+
+def check_positions(coords, errors, path="coordinates"):
+    """Recursively validate a coordinates array: every position must be
+    [lon, lat] with no Z value and coordinates in valid ranges."""
+    if not isinstance(coords, list):
+        errors.append(f"{path}: expected an array, got {type(coords).__name__}")
+        return
+    if coords and all(isinstance(v, (int, float)) and not isinstance(v, bool) for v in coords):
+        # This is a single position
+        if len(coords) != 2:
+            errors.append(
+                f"{path}: position has {len(coords)} values {coords} -- "
+                "must be exactly [longitude, latitude] (no Z coordinate)"
+            )
+            return
+        lon, lat = coords
+        if not -180 <= lon <= 180:
+            errors.append(f"{path}: longitude {lon} outside [-180, 180]")
+        if not -90 <= lat <= 90:
+            errors.append(f"{path}: latitude {lat} outside [-90, 90]")
+        return
+    for i, item in enumerate(coords):
+        check_positions(item, errors, f"{path}[{i}]")
+
+
+def check_geometry(geom, errors, path="geometry"):
+    if geom is None:
+        return  # empty route -- valid by convention
+    if not isinstance(geom, dict):
+        errors.append(f"{path}: must be an object or null")
+        return
+    gtype = geom.get("type")
+    if gtype not in GEOMETRY_TYPES:
+        errors.append(f"{path}: unknown geometry type {gtype!r}")
+        return
+    if gtype == "GeometryCollection":
+        for i, g in enumerate(geom.get("geometries", [])):
+            check_geometry(g, errors, f"{path}.geometries[{i}]")
+        return
+    if "coordinates" not in geom:
+        errors.append(f"{path}: missing 'coordinates'")
+        return
+    check_positions(geom["coordinates"], errors, f"{path}.coordinates")
+
+
+def check_duplicate_id(filepath, errors):
+    """Flag the same filename appearing in more than one fuel folder."""
+    try:
+        fuel_dirs = [d for d in ROUTES_DIR.iterdir() if d.is_dir()]
+    except FileNotFoundError:
+        return
+    hits = [d.name for d in fuel_dirs if (d / filepath.name).exists()]
+    if len(hits) > 1:
+        errors.append(
+            f"{filepath.name} exists in more than one fuel folder: {', '.join(sorted(hits))} "
+            "-- ProjectIDs must live in exactly one"
+        )
+
+
+def validate_file(filepath):
+    """Return (errors, warnings) lists of strings for one file."""
+    errors = []
+    warnings = []
+    filepath = Path(filepath)
+
+    m = FILENAME_RE.match(filepath.name)
+    if not m:
+        errors.append(
+            f"filename {filepath.name!r} does not match the required pattern "
+            "P####.geojson or P####-compressor-stations.geojson"
+        )
+        project_id = None
+    else:
+        project_id = m.group(1)
+
+    try:
+        text = filepath.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as e:
+        errors.append(f"cannot read file: {e}")
+        return errors, warnings
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as e:
+        errors.append(f"invalid JSON: {e}")
+        return errors, warnings
+
+    if isinstance(data, dict) and data.get("type") == "Feature":
+        # A single top-level Feature is valid GeoJSON (common geojson.io
+        # export); treat it as a one-feature collection.
+        data = {"type": "FeatureCollection", "features": [data], "crs": data.get("crs")}
+
+    if not isinstance(data, dict) or data.get("type") != "FeatureCollection":
+        errors.append("top level must be a FeatureCollection (or a single Feature)")
+        return errors, warnings
+
+    crs = data.get("crs")
+    if crs is not None:
+        crs_name = crs.get("properties", {}).get("name") if isinstance(crs, dict) else None
+        if crs_name not in ACCEPTED_CRS:
+            errors.append(
+                f"crs is {crs_name!r} -- GeoJSON must be WGS 84 (EPSG:4326 / CRS84); "
+                "reproject before committing"
+            )
+
+    features = data.get("features")
+    if not isinstance(features, list):
+        errors.append("'features' must be an array")
+        return errors, warnings
+
+    for i, feat in enumerate(features):
+        fpath = f"features[{i}]"
+        if not isinstance(feat, dict) or feat.get("type") != "Feature":
+            errors.append(f"{fpath}: must be an object with type 'Feature'")
+            continue
+        check_geometry(feat.get("geometry"), errors, f"{fpath}.geometry")
+        props = feat.get("properties")
+        if isinstance(props, dict) and project_id is not None:
+            pid = props.get("ProjectID")
+            if pid is not None and str(pid).strip() != project_id:
+                warnings.append(
+                    f"{fpath}: ProjectID property {pid!r} does not match filename ({project_id})"
+                )
+
+    if filepath.resolve().is_relative_to(ROUTES_DIR):
+        check_duplicate_id(filepath, errors)
+
+    return errors, warnings
+
+
+def main(argv):
+    if not argv or argv == ["--help"] or argv == ["-h"]:
+        print(__doc__.strip())
+        return 2
+
+    if argv == ["--all"]:
+        files = sorted(ROUTES_DIR.glob("*/*.geojson"))
+        if not files:
+            print(f"no .geojson files found under {ROUTES_DIR}", file=sys.stderr)
+            return 2
+    else:
+        files = [Path(a) for a in argv]
+
+    n_failed = 0
+    n_warned = 0
+    for f in files:
+        errors, warnings = validate_file(f)
+        if errors:
+            n_failed += 1
+            print(f"FAIL  {f}")
+            shown = errors[:20]
+            for err in shown:
+                print(f"      - {err}")
+            if len(errors) > len(shown):
+                print(f"      ... and {len(errors) - len(shown)} more errors")
+        if warnings:
+            n_warned += 1
+            print(f"WARN  {f}")
+            for w in warnings:
+                print(f"      - {w}")
+
+    print(
+        f"\nchecked {len(files)} file(s): {len(files) - n_failed} passed, "
+        f"{n_failed} failed, {n_warned} with warnings"
+    )
+    return 1 if n_failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## what this does

**validation on every pr** (`.github/workflows/validate-routes.yml`)
runs `scripts/validate_geojson.py` on the route files changed in the pr. fails if a file:
- is not valid json / geojson
- declares a crs other than wgs 84 (epsg:4326 / crs84)
- contains z coordinates
- has coordinates outside valid lon/lat ranges
- is not named `P####.geojson` (or `P####-compressor-stations.geojson`)
- uses a projectid that already exists in a different fuel folder

a filename/projectid-property mismatch is a warning only (copied routes are common). bare top-level `Feature` files (geojson.io exports) are accepted. the current tree passes 6,778/6,778. run locally with `python3 scripts/validate_geojson.py --all` or via workflow_dispatch for a full audit. stdlib only, no gdal needed.

**the `normalized` branch** (`.github/workflows/normalize-routes.yml`)
on every push to main that touches routes: validate all files, rebuild the normalized tree, push to the `normalized` branch only if content changed. the branch self-bootstraps on first run (orphan, no shared history) and carries its own readme marking it generated.

main keeps the original files untouched (original metadata, full coordinate precision, for researchers who scrape routes). normalized files are canonical featurecollections with:
- coordinates rounded to 6 decimal places (~10 cm), z dropped
- legacy `crs` member removed
- `projectid` property on every feature, matching the filename (an original differing projectid is preserved as `sourceprojectid`)
- truncated embedded-geometry stub properties (254-char dbf artifacts, 23 files) dropped

output is deterministic (verified byte-identical across runs) and shrinks the data 242 mb → 147 mb. the full normalized output passes validation with zero warnings.

**readme**
fixes the `individual-files` → `individual-routes` folder name and documents the checks and the main-vs-normalized contract.