### PR TITLE
drop embedded point/polygon features from normalized route layers

### DIFF
--- a/scripts/normalize_geojson.py
+++ b/scripts/normalize_geojson.py
@@ -17,6 +17,11 @@ Normalization rules:
   - other feature properties and feature ids are preserved as-is, except
     properties whose value is an embedded JSON copy of a geometry (e.g. a
     GEOJSON field from a source-data export), which are dropped as redundant
+  - route files (P####.geojson, not -compressor-stations files) drop
+    Point/MultiPoint/Polygon/MultiPolygon features -- embedded valves, pig
+    launchers, markers, traced station outlines -- so the route layer is
+    lines only; the points stay available in the originals on main. As a
+    safeguard, nothing is dropped from a file with no line features at all.
   - files with no features become a single null-geometry feature, matching
     the empty-route convention in README.md
   - deterministic serialization: one feature per line, stable key order,
@@ -56,6 +61,9 @@ Compared to the original files on `main`, every file here:
 - carries a `ProjectID` property on every feature, matching the filename
   (where the original file carried a different `ProjectID`, that value is
   preserved as `SourceProjectID`)
+- if it is a route file (not a `-compressor-stations` file), contains only
+  line geometries -- embedded point features (valves, pig launchers,
+  markers) and traced station polygons are dropped
 
 If you want the original files exactly as researchers submitted them --
 original metadata, original coordinate precision -- use the `main` branch.
@@ -72,6 +80,21 @@ EMBEDDED_GEOMETRY_RE = re.compile(
     r'^\s*\{\s*"type"\s*:\s*"(%s)"\s*,\s*"(coordinates|geometries)"'
     % "|".join(GEOMETRY_TYPES)
 )
+
+
+LINE_GEOMETRY_TYPES = {"LineString", "MultiLineString"}
+
+
+def has_line_geometry(geom):
+    """True if a geometry is (or, for a GeometryCollection, contains) a
+    LineString or MultiLineString. Null geometries count as line-compatible
+    so empty-route placeholder features are never dropped."""
+    if geom is None:
+        return True
+    gtype = geom.get("type")
+    if gtype == "GeometryCollection":
+        return any(has_line_geometry(g) for g in geom.get("geometries", []))
+    return gtype in LINE_GEOMETRY_TYPES
 
 
 def is_embedded_geometry(value):
@@ -143,6 +166,15 @@ def normalize_file(src, precision):
 
     m = FILENAME_RE.match(src.name)
     project_id = m.group(1) if m else None
+    is_route_file = m is not None and m.group(2) is None
+
+    # Route layers are lines only: drop embedded point/polygon features
+    # (valves, markers, station outlines), but never from a file that has
+    # no line features at all -- emptying it would misread as "no route".
+    if is_route_file:
+        line_features = [f for f in features if has_line_geometry(f.get("geometry"))]
+        if line_features:
+            features = line_features
 
     if not features:
         features = [{"type": "Feature", "properties": {}, "geometry": None}]

--- a/scripts/validate_geojson.py
+++ b/scripts/validate_geojson.py
@@ -12,6 +12,10 @@ Checks each file for:
 Warnings (reported but do not fail validation):
   - a ProjectID property that does not match the filename (this is common
     when a route was copied from a related project)
+  - a route file (P####.geojson, not a -compressor-stations file) containing
+    Point/MultiPoint/Polygon/MultiPolygon features -- embedded valves,
+    markers, or traced station outlines. These are dropped when building the
+    normalized branch; station points belong in a -compressor-stations file.
 
 Empty routes (geometry: null) are valid -- see README.md.
 
@@ -47,6 +51,20 @@ GEOMETRY_TYPES = {
     "Point", "MultiPoint", "LineString", "MultiLineString",
     "Polygon", "MultiPolygon", "GeometryCollection",
 }
+
+LINE_GEOMETRY_TYPES = {"LineString", "MultiLineString"}
+
+
+def has_line_geometry(geom):
+    """True if a geometry is (or, for a GeometryCollection, contains) a
+    LineString or MultiLineString. Null geometries count as line-compatible
+    (empty-route placeholder)."""
+    if not isinstance(geom, dict):
+        return geom is None
+    gtype = geom.get("type")
+    if gtype == "GeometryCollection":
+        return any(has_line_geometry(g) for g in geom.get("geometries", []))
+    return gtype in LINE_GEOMETRY_TYPES
 
 
 def check_positions(coords, errors, path="coordinates"):
@@ -120,8 +138,10 @@ def validate_file(filepath):
             "P####.geojson or P####-compressor-stations.geojson"
         )
         project_id = None
+        is_route_file = False
     else:
         project_id = m.group(1)
+        is_route_file = m.group(2) is None
 
     try:
         text = filepath.read_text(encoding="utf-8")
@@ -158,12 +178,15 @@ def validate_file(filepath):
         errors.append("'features' must be an array")
         return errors, warnings
 
+    n_non_line = 0
     for i, feat in enumerate(features):
         fpath = f"features[{i}]"
         if not isinstance(feat, dict) or feat.get("type") != "Feature":
             errors.append(f"{fpath}: must be an object with type 'Feature'")
             continue
         check_geometry(feat.get("geometry"), errors, f"{fpath}.geometry")
+        if is_route_file and not has_line_geometry(feat.get("geometry")):
+            n_non_line += 1
         props = feat.get("properties")
         if isinstance(props, dict) and project_id is not None:
             pid = props.get("ProjectID")
@@ -171,6 +194,13 @@ def validate_file(filepath):
                 warnings.append(
                     f"{fpath}: ProjectID property {pid!r} does not match filename ({project_id})"
                 )
+
+    if n_non_line:
+        warnings.append(
+            f"{n_non_line} point/polygon feature(s) in a route file -- these are "
+            "dropped from the normalized branch; station points belong in a "
+            "-compressor-stations file"
+        )
 
     if filepath.resolve().is_relative_to(ROUTES_DIR):
         check_duplicate_id(filepath, errors)


### PR DESCRIPTION
Closes #2.

Route files (`P####.geojson`, but not `-compressor-stations` files) now keep only line geometries when the `normalized` branch is built — embedded valves, pig launchers, markers, and traced station outlines are dropped. Originals on `main` are untouched, per the repo convention.

- `scripts/normalize_geojson.py`: filters Point/MultiPoint/Polygon/MultiPolygon features from route files. Safeguard: a file with no line features at all is left as-is, so a points-only file never silently becomes an empty route.
- `scripts/validate_geojson.py`: new non-fatal warning when a route file contains point/polygon features, so future submissions are flagged in CI.

Verified: full validation passes (6,785/6,785, with exactly the 19 expected new warnings); a before/after build of the normalized tree differs in exactly those 19 files plus the branch README; spot-checks confirm only point features were removed (e.g. P0152: 1021 → 1019 features, all LineString). All 19 affected files contain only auxiliary equipment points, never route geometry.