### PR TITLE
restructure readme by audience, add repo layout, scrub personal names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,52 @@
 # GOIT-GGIT-pipeline-routes
-This is a GitHub repository at Global Energy Monitor to store pipeline routes.
 
-Individual routes are stored as `[ProjectID].geojson` in the `data/individual-routes` folder, split by fuel into `gas-pipelines`, `liquid-pipelines`, and `hydrogen-pipelines`. Each ProjectID lives in exactly one fuel folder.
+Pipeline route geometries for Global Energy Monitor's [Global Oil Infrastructure Tracker (GOIT)](https://globalenergymonitor.org/projects/global-oil-infrastructure-tracker/) and [Global Gas Infrastructure Tracker (GGIT)](https://globalenergymonitor.org/projects/global-gas-infrastructure-tracker/), plus hydrogen pipelines. Each route is a standalone GeoJSON file keyed by its ProjectID in the tracker database; this repo is the source of truth for route geometry, and downstream maps are built from it automatically.
 
-## Every project has a GeoJSON file associated with it.
-If a given project does not have a route, either because it's a capacity expansion with no actual new pipeline associated with it, or because we haven't created the route yet or cannot find a map to trace online, we STILL create a `.geojson` file for it, it's just stored as an **empty GeoJSON file** (i.e., `None`-type geometry).
+**If you're a researcher adding or updating routes**, you only need the first three sections. The rest documents automated checks and maintainer tooling.
 
-An example of an "empty" GeoJSON file could look something like this:
+## Repository layout
+
 ```
+data/individual-routes/
+├── gas-pipelines/        # one P####.geojson per gas pipeline project
+├── liquid-pipelines/     # oil / NGL / products pipelines
+└── hydrogen-pipelines/
+scripts/                  # validation and QC tools (documented below)
+```
+
+Route files are named `[ProjectID].geojson` (e.g. `P1234.geojson`), and each ProjectID lives in exactly one fuel folder. Some projects also have a `[ProjectID]-compressor-stations.geojson` sidecar file holding point features for compressor stations.
+
+## File conventions
+
+**Every project gets a file, even without a route.** If a project has no route — it's a capacity expansion with no new pipeline, or no map exists to trace yet — we still create a `.geojson` for it with empty (`null`) geometry, like this (also at [`data/example-empty-route.geojson`](data/example-empty-route.geojson)):
+
+```json
 {
     "type": "FeatureCollection",
     "features": [
         {
-            "type": "Feature", 
+            "type": "Feature",
             "geometry": null
         }
     ]
 }
 ```
 
-## Contribute by creating a new branch and a pull request
+**Coordinates are WGS 84.** The [GeoJSON spec](https://geojson.org/) fixes the coordinate reference system as WGS 84 (EPSG:4326), so no `crs` member is needed — or allowed. Positions are `[longitude, latitude]` pairs only, no Z/elevation values.
 
-If you update a route or multiple routes...
+**Only the filename identifies the route.** You don't need to include any pipeline attributes (name, status, etc.) in the file's properties — the `[ProjectID].geojson` filename is the only required label. Extra properties are fine but unnecessary.
+
+## Contributing routes
+
 1. Create a _new_ branch with a short, informative title (for example, `firstname-p9998-p9999`)
 2. Add your changes to the branch and push it to the repository
-3. Create a pull request and assign it to Baird for review
+3. Create a pull request and assign it to the repo maintainer for review
 
-## How can I create a GeoJSON file from scratch for a route?
+### Creating or editing a route file
 
-* If you are comfortable working in [QGIS](https://www.qgis.org/en/site/) or [JOSM](https://josm.openstreetmap.de/), those are the most complex ways to do it. Create a route or edit an existing one and re-export it as a GeoJSON file. You __don't__ need to include any specific information about the pipeline itself (name, status, etc.) in the GeoJSON file; the __only__ way I ask you to label it is via the title: `[ProjectID].geojson`. (You can of course include more info, but it's not necessary.)
-
-* If you're creating a new route from scratch, and the tools above aren't familiar, try using [geojson.io](https://geojson.io/) or [placemark.io](https://play.placemark.io/).
-
-* If you're editing an existing route, you can import the GeoJSON file that already exists for it
-
-## Coordinate reference system
-
-The [GeoJSON](https://geojson.org/) file format specification says that GeoJSON files use a WSG 84 (EPSG:4326) coordinate reference system, so this is expected for all pipelines and no crs is required in the GeoJSON file.
+* **Easiest:** draw the route in [geojson.io](https://geojson.io/) or [placemark.io](https://play.placemark.io/) and save it as `[ProjectID].geojson`.
+* **Most capable:** [QGIS](https://www.qgis.org/en/site/) or [JOSM](https://josm.openstreetmap.de/), if you're comfortable with them — create or edit a route and export it as GeoJSON.
+* **Editing an existing route:** import the project's current file from this repo into any of the tools above, edit, and re-export.
 
 ## Automated checks
 
@@ -63,7 +73,7 @@ Before routes from an update cycle enter the repo, `scripts/qc_routes.py` runs a
 **1. Report (read-only) — scan a folder and see what's good:**
 
 ```
-python3 scripts/qc_routes.py "/path/to/PIPELINE ROUTES .../Isabel"   # a researcher's folder
+python3 scripts/qc_routes.py "/path/to/PIPELINE ROUTES .../<researcher folder>"
 python3 scripts/qc_routes.py path/to/P1234.geojson                   # specific files
 ```
 
@@ -80,8 +90,8 @@ Each route is graded **PASS** / **WARN** / **FAIL**. On top of the CI checks (va
 **2. Copy (stages files into the repo) — only after you've read the report:**
 
 ```
-python3 scripts/qc_routes.py "/path/.../Isabel" --copy                       # copies PASS routes
-python3 scripts/qc_routes.py "/path/.../Isabel" --copy --include P1897 P3961  # also copy these WARN routes
+python3 scripts/qc_routes.py "/path/.../<researcher folder>" --copy                       # copies PASS routes
+python3 scripts/qc_routes.py "/path/.../<researcher folder>" --copy --include P1897 P3961  # also copy these WARN routes
 ```
 
 The copy phase places routes in `data/individual-routes/<fuel>/` (fuel from the DB tab). **PASS** routes are copied automatically; **WARN** routes only when named with `--include`; **FAIL** routes are always left behind. Nothing is committed — review, then create a branch and PR as usual.


### PR DESCRIPTION
reorganizes the readme so researcher instructions come first and maintainer tooling last, adds a repo layout tree and file-convention section, fixes the wgs 84 typo, and replaces personal names with roles/placeholders (public repo).